### PR TITLE
Fix nested name lists

### DIFF
--- a/data/112/606/120/7/1126061207.geojson
+++ b/data/112/606/120/7/1126061207.geojson
@@ -31,9 +31,6 @@
         "Sonnenberg"
     ],
     "name:eng_x_variant":[
-        [
-            "Sonnenberg"
-        ],
         "Wolfhausen / Sonnenberg"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126061207,
-    "wof:lastmodified":1566642200,
+    "wof:lastmodified":1568050067,
     "wof:name":"Sonnenberg",
     "wof:parent_id":1125950163,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/190/7/1126061907.geojson
+++ b/data/112/606/190/7/1126061907.geojson
@@ -31,9 +31,6 @@
         "Oberfeld"
     ],
     "name:eng_x_variant":[
-        [
-            "Oberfeld"
-        ],
         "Kloten / Oberfeld"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126061907,
-    "wof:lastmodified":1566642210,
+    "wof:lastmodified":1568050066,
     "wof:name":"Oberfeld",
     "wof:parent_id":1125851437,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/195/7/1126061957.geojson
+++ b/data/112/606/195/7/1126061957.geojson
@@ -31,9 +31,6 @@
         "Sonnenberg"
     ],
     "name:eng_x_variant":[
-        [
-            "Sonnenberg"
-        ],
         "Niederglatt / Sonnenberg"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126061957,
-    "wof:lastmodified":1566642171,
+    "wof:lastmodified":1568050067,
     "wof:name":"Sonnenberg",
     "wof:parent_id":1125851767,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/205/3/1126062053.geojson
+++ b/data/112/606/205/3/1126062053.geojson
@@ -31,9 +31,6 @@
         "Hard"
     ],
     "name:eng_x_variant":[
-        [
-            "Hard"
-        ],
         "Regensdorf / Hard"
     ],
     "name:fra_x_preferred":[
@@ -88,7 +85,7 @@
         }
     ],
     "wof:id":1126062053,
-    "wof:lastmodified":1566642195,
+    "wof:lastmodified":1568050069,
     "wof:name":"Hard",
     "wof:parent_id":101854445,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/208/5/1126062085.geojson
+++ b/data/112/606/208/5/1126062085.geojson
@@ -31,9 +31,6 @@
         "Sonnenberg"
     ],
     "name:eng_x_variant":[
-        [
-            "Sonnenberg"
-        ],
         "Sch\u00f6fflisdorf / Sonnenberg"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126062085,
-    "wof:lastmodified":1566642228,
+    "wof:lastmodified":1568050068,
     "wof:name":"Sonnenberg",
     "wof:parent_id":1125858099,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/326/1/1126063261.geojson
+++ b/data/112/606/326/1/1126063261.geojson
@@ -31,9 +31,6 @@
         "Oberfeld"
     ],
     "name:eng_x_variant":[
-        [
-            "Oberfeld"
-        ],
         "Oetwil / Oberfeld"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126063261,
-    "wof:lastmodified":1566642240,
+    "wof:lastmodified":1568050068,
     "wof:name":"Oberfeld",
     "wof:parent_id":1108980331,
     "wof:placetype":"neighbourhood",

--- a/data/112/606/412/9/1126064129.geojson
+++ b/data/112/606/412/9/1126064129.geojson
@@ -31,9 +31,6 @@
         "Sonnenberg"
     ],
     "name:eng_x_variant":[
-        [
-            "Sonnenberg"
-        ],
         "D\u00fcbendorf / Sonnenberg"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1126064129,
-    "wof:lastmodified":1566642184,
+    "wof:lastmodified":1568050065,
     "wof:name":"Sonnenberg",
     "wof:parent_id":1125826975,
     "wof:placetype":"neighbourhood",

--- a/data/139/439/552/5/1394395525.geojson
+++ b/data/139/439/552/5/1394395525.geojson
@@ -28,9 +28,6 @@
         "Rosenberg"
     ],
     "name:eng_x_variant":[
-        [
-            "Rosenberg"
-        ],
         "Feldbach / Rosenberg"
     ],
     "qs_pg:aaroncc":"CH",
@@ -76,7 +73,7 @@
         }
     ],
     "wof:id":1394395525,
-    "wof:lastmodified":1566640647,
+    "wof:lastmodified":1568050066,
     "wof:name":"Rosenberg",
     "wof:parent_id":1125908497,
     "wof:placetype":"neighbourhood",

--- a/data/139/439/805/1/1394398051.geojson
+++ b/data/139/439/805/1/1394398051.geojson
@@ -28,9 +28,6 @@
         "Liebenfels"
     ],
     "name:eng_x_variant":[
-        [
-            "Feldbach"
-        ],
         "Feldbach / Liebenfels"
     ],
     "name:nld_x_preferred":[
@@ -82,7 +79,7 @@
         }
     ],
     "wof:id":1394398051,
-    "wof:lastmodified":1566640588,
+    "wof:lastmodified":1568050065,
     "wof:name":"Liebenfels",
     "wof:parent_id":1125908497,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1701

- Removes any nested lists in `name:*` properties in 9 `admin-ch` records
- Exportifies

No PIP required, can merge once approved.