### PR TITLE
Update Kirchberg record

### DIFF
--- a/data/101/854/119/101854119.geojson
+++ b/data/101/854/119/101854119.geojson
@@ -21,10 +21,10 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "name:als_x_preferred":[
-        "Kirchberg SG"
+        "Kirchberg BE"
     ],
     "name:als_x_variant":[
-        "Kirchberg BE"
+        "Kirchberg"
     ],
     "name:cat_x_preferred":[
         "Kirchberg"
@@ -39,10 +39,9 @@
         "Kirchberg"
     ],
     "name:deu_x_preferred":[
-        "Kirchberg SG"
+        "Kirchberg BE"
     ],
     "name:deu_x_variant":[
-        "Kirchberg BE",
         "Kirchberg"
     ],
     "name:eng_x_preferred":[
@@ -52,10 +51,9 @@
         "Kirchberg BE"
     ],
     "name:epo_x_preferred":[
-        "Kirchberg SG"
+        "Kirchberg BE"
     ],
     "name:epo_x_variant":[
-        "Kirchberg BE",
         "Kirchberg"
     ],
     "name:eus_x_preferred":[
@@ -161,7 +159,7 @@
         "gp:id":782912,
         "qs_pg:id":320308,
         "wd:id":"Q66463",
-        "wk:page":"Kirchberg, St. Gallen"
+        "wk:page":"Kirchberg,_Bern"
     },
     "wof:concordances_alt":{
         "qs_pg:id":1220468

--- a/data/101/854/119/101854119.geojson
+++ b/data/101/854/119/101854119.geojson
@@ -185,7 +185,7 @@
         }
     ],
     "wof:id":101854119,
-    "wof:lastmodified":1598919072,
+    "wof:lastmodified":1603217372,
     "wof:name":"Kirchberg",
     "wof:parent_id":404569999,
     "wof:placetype":"locality",


### PR DESCRIPTION
Replaces https://github.com/whosonfirst-data/whosonfirst-data-admin-ch/pull/19/.

This PR corrects names and concordances to reflect the correct Kirchberg record.