### PR TITLE
Update locality names

### DIFF
--- a/data/112/610/572/1/1126105721.geojson
+++ b/data/112/610/572/1/1126105721.geojson
@@ -18,40 +18,70 @@
     "lbl:longitude":7.96957,
     "lbl:max_zoom":18.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
     "name:ces_x_preferred":[
+        "Striegel"
+    ],
+    "name:ces_x_variant":[
         "Spiegel"
     ],
     "name:dan_x_preferred":[
+        "Striegel"
+    ],
+    "name:dan_x_variant":[
         "Spiegel"
     ],
     "name:deu_x_preferred":[
+        "Striegel"
+    ],
+    "name:deu_x_variant":[
+        "Spiegel"
+    ],
+    "name:eng_x_preferred":[
+        "Striegel"
+    ],
+    "name:eng_x_variant":[
         "Spiegel"
     ],
     "name:fra_x_preferred":[
+        "Striegel"
+    ],
+    "name:fra_x_variant":[
         "Spiegel"
     ],
-    "name:heb_x_preferred":[
+    "name:heb_x_variant":[
         "\u05e9\u05e4\u05d9\u05d2\u05dc"
     ],
     "name:ita_x_preferred":[
+        "Striegel"
+    ],
+    "name:ita_x_variant":[
         "Spiegel"
     ],
-    "name:jpn_x_preferred":[
+    "name:jpn_x_variant":[
         "\u30b7\u30e5\u30d4\u30fc\u30b2\u30eb"
     ],
     "name:nld_x_preferred":[
+        "Striegel"
+    ],
+    "name:nld_x_variant":[
         "Spiegel"
     ],
-    "name:rus_x_preferred":[
+    "name:rus_x_variant":[
         "\u0428\u043f\u0438\u0433\u0435\u043b\u044c"
     ],
     "name:spa_x_preferred":[
+        "Striegel"
+    ],
+    "name:spa_x_variant":[
         "Spiegel"
     ],
     "name:swe_x_preferred":[
+        "Striegel"
+    ],
+    "name:swe_x_variant":[
         "Spiegel"
     ],
     "qs_pg:aaroncc":"CH",
@@ -82,10 +112,10 @@
     "woe:placetype":"Suburb",
     "wof:belongsto":[
         102191581,
-        404570915,
         85633051,
-        101854337,
         102062851,
+        404570915,
+        101854337,
         85682329
     ],
     "wof:breaches":[],
@@ -109,8 +139,8 @@
         }
     ],
     "wof:id":1126105721,
-    "wof:lastmodified":1566641700,
-    "wof:name":"Spiegel",
+    "wof:lastmodified":1622668858,
+    "wof:name":"Striegel",
     "wof:parent_id":101854337,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ch",


### PR DESCRIPTION
This PR fixes name translations and the `wof:name` values in the locality record for Striegel, Switzerland.

This name can be confirmed on other mapping platforms and shares the name with this train station: https://en.wikipedia.org/wiki/Walterswil-Striegel_railway_station