### PR TITLE
Add airport codes as name variants

### DIFF
--- a/data/102/553/907/102553907.geojson
+++ b/data/102/553/907/102553907.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"8.3025,47.26472222,8.3025,47.26472222",
+    "geom:bbox":"8.3025,47.264722,8.3025,47.264722",
     "geom:latitude":47.264722,
     "geom:longitude":8.3025,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Buttwil Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSZU"
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Buttwil"
@@ -52,7 +55,7 @@
         "wd:id":"Q15809881"
     },
     "wof:country":"CH",
-    "wof:geomhash":"cfff470d83990d6c8f63d471a91da067",
+    "wof:geomhash":"7ab369526c6d35a1c6d46215cfcccdbc",
     "wof:hierarchy":[
         {
             "campus_id":102553907,
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102553907,
-    "wof:lastmodified":1566639364,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Buttwil",
     "wof:parent_id":1125770941,
     "wof:placetype":"campus",
@@ -79,9 +82,9 @@
 },
   "bbox": [
     8.3025,
-    47.26472222,
+    47.264722,
     8.3025,
-    47.26472222
+    47.264722
 ],
-  "geometry": {"coordinates":[8.3025,47.26472222],"type":"Point"}
+  "geometry": {"coordinates":[8.3025,47.264722],"type":"Point"}
 }

--- a/data/102/553/909/102553909.geojson
+++ b/data/102/553/909/102553909.geojson
@@ -16,6 +16,9 @@
     "name:eng_x_preferred":[
         "Luzern-Beromunster Airport"
     ],
+    "name:eng_x_variant":[
+        "LSZO"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Luzern-Beromunster"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553909,
-    "wof:lastmodified":1566639364,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Luzern-Beromunster",
     "wof:parent_id":1125931301,
     "wof:placetype":"campus",

--- a/data/102/553/921/102553921.geojson
+++ b/data/102/553/921/102553921.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"7.09527778,46.59527778,7.09527778,46.59527778",
+    "geom:bbox":"7.095278,46.595278,7.095278,46.595278",
     "geom:latitude":46.595278,
     "geom:longitude":7.095278,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Gruy\u00e8res Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSGT"
     ],
     "name:jpn_x_preferred":[
         "\u30b0\u30ea\u30e5\u30a4\u30a8\u30fc\u30eb\u7a7a\u6e2f"
@@ -49,7 +52,7 @@
         "wd:id":"Q1433614"
     },
     "wof:country":"CH",
-    "wof:geomhash":"bc94175ee8ac95fb224c21142cb99ade",
+    "wof:geomhash":"5670800c9924c920f9c38ad63d019742",
     "wof:hierarchy":[
         {
             "campus_id":102553921,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553921,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Aerodrome Gruyeres",
     "wof:parent_id":1125898081,
     "wof:placetype":"campus",
@@ -75,10 +78,10 @@
     ]
 },
   "bbox": [
-    7.09527778,
-    46.59527778,
-    7.09527778,
-    46.59527778
+    7.095278,
+    46.595278,
+    7.095278,
+    46.595278
 ],
-  "geometry": {"coordinates":[7.09527778,46.59527778],"type":"Point"}
+  "geometry": {"coordinates":[7.095278,46.595278],"type":"Point"}
 }

--- a/data/102/553/923/102553923.geojson
+++ b/data/102/553/923/102553923.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"9.26277778,47.50888889,9.26277778,47.50888889",
+    "geom:bbox":"9.262778,47.508889,9.262778,47.508889",
     "geom:latitude":47.508889,
     "geom:longitude":9.262778,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Sitterdorf Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSZV"
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Sitterdorf"
@@ -52,7 +55,7 @@
         "wd:id":"Q15110799"
     },
     "wof:country":"CH",
-    "wof:geomhash":"36925799e0f0a8752c7e9120b88e9a5c",
+    "wof:geomhash":"1c2bd9811809e653205f3ce80765b2ee",
     "wof:hierarchy":[
         {
             "campus_id":102553923,
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102553923,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Sitterdorf",
     "wof:parent_id":1293134977,
     "wof:placetype":"campus",
@@ -78,10 +81,10 @@
     ]
 },
   "bbox": [
-    9.26277778,
-    47.50888889,
-    9.26277778,
-    47.50888889
+    9.262778,
+    47.508889,
+    9.262778,
+    47.508889
 ],
-  "geometry": {"coordinates":[9.26277778,47.50888889],"type":"Point"}
+  "geometry": {"coordinates":[9.262778,47.508889],"type":"Point"}
 }

--- a/data/102/553/925/102553925.geojson
+++ b/data/102/553/925/102553925.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Biel-Kappelen Airport"
     ],
+    "name:eng_x_variant":[
+        "LSZP"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Biel-Kappelen"
     ],
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102553925,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Biel-Kappelen",
     "wof:parent_id":1125800027,
     "wof:placetype":"campus",

--- a/data/102/553/931/102553931.geojson
+++ b/data/102/553/931/102553931.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"6.25805556,46.40638889,6.25805556,46.40638889",
+    "geom:bbox":"6.258056,46.406389,6.258056,46.406389",
     "geom:latitude":46.406389,
     "geom:longitude":6.258056,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "La C\u00f4te Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSGP"
     ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0644\u0627 \u06a9\u0648\u062a\u0647"
@@ -61,7 +64,7 @@
         "wd:id":"Q6462166"
     },
     "wof:country":"CH",
-    "wof:geomhash":"889a520496b67c728e5ff4ef26ccf24d",
+    "wof:geomhash":"aae70b1c037bbec01d35236c8d01e2b1",
     "wof:hierarchy":[
         {
             "campus_id":102553931,
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":102553931,
-    "wof:lastmodified":1566639364,
+    "wof:lastmodified":1631733986,
     "wof:name":"Aerodrome de la Cote",
     "wof:parent_id":1193046703,
     "wof:placetype":"campus",
@@ -87,10 +90,10 @@
     ]
 },
   "bbox": [
-    6.25805556,
-    46.40638889,
-    6.25805556,
-    46.40638889
+    6.258056,
+    46.406389,
+    6.258056,
+    46.406389
 ],
-  "geometry": {"coordinates":[6.25805556,46.40638889],"type":"Point"}
+  "geometry": {"coordinates":[6.258056,46.406389],"type":"Point"}
 }

--- a/data/102/553/937/102553937.geojson
+++ b/data/102/553/937/102553937.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"9.48194444444,47.015,9.48194444444,47.015",
+    "geom:bbox":"9.481944,47.015,9.481944,47.015",
     "geom:latitude":47.015,
     "geom:longitude":9.481944,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Bad Ragaz Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSZE"
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Bad Ragaz"
@@ -49,7 +52,7 @@
         "wd:id":"Q1433503"
     },
     "wof:country":"CH",
-    "wof:geomhash":"6e36a3b6b358f361fe960e54d24c84f8",
+    "wof:geomhash":"24f6af1dbb6d1679c60d9d7bd79aad0e",
     "wof:hierarchy":[
         {
             "campus_id":102553937,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553937,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Bad Ragaz",
     "wof:parent_id":1327368731,
     "wof:placetype":"campus",
@@ -75,10 +78,10 @@
     ]
 },
   "bbox": [
-    9.4819444444444,
+    9.481944,
     47.015,
-    9.4819444444444,
+    9.481944,
     47.015
 ],
-  "geometry": {"coordinates":[9.4819444444444,47.015],"type":"Point"}
+  "geometry": {"coordinates":[9.481944,47.015],"type":"Point"}
 }

--- a/data/102/553/939/102553939.geojson
+++ b/data/102/553/939/102553939.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"9.04111111111,47.1713888889,9.04111111111,47.1713888889",
+    "geom:bbox":"9.041111,47.171389,9.041111,47.171389",
     "geom:latitude":47.171389,
     "geom:longitude":9.041111,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Sch\u00e4nis Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSZX"
     ],
     "oa:elevation_ft":"1365",
     "oa:type":"small_airport",
@@ -46,7 +49,7 @@
         "wd:id":"Q1297750"
     },
     "wof:country":"CH",
-    "wof:geomhash":"51aaae761eab3d4fdf3dba0219466334",
+    "wof:geomhash":"76be254d8c6539b24b74055e75bfd12f",
     "wof:hierarchy":[
         {
             "campus_id":102553939,
@@ -60,7 +63,7 @@
         }
     ],
     "wof:id":102553939,
-    "wof:lastmodified":1566639364,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Schanis",
     "wof:parent_id":101854255,
     "wof:placetype":"campus",
@@ -72,10 +75,10 @@
     ]
 },
   "bbox": [
-    9.0411111111111,
-    47.171388888889,
-    9.0411111111111,
-    47.171388888889
+    9.041111,
+    47.171389,
+    9.041111,
+    47.171389
 ],
-  "geometry": {"coordinates":[9.0411111111111,47.171388888889],"type":"Point"}
+  "geometry": {"coordinates":[9.041111,47.171389],"type":"Point"}
 }

--- a/data/102/553/941/102553941.geojson
+++ b/data/102/553/941/102553941.geojson
@@ -16,6 +16,9 @@
     "name:eng_x_preferred":[
         "Lommis Airport"
     ],
+    "name:eng_x_variant":[
+        "LSZT"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Lommis"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553941,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Lommis",
     "wof:parent_id":1125788029,
     "wof:placetype":"campus",

--- a/data/102/553/945/102553945.geojson
+++ b/data/102/553/945/102553945.geojson
@@ -19,6 +19,10 @@
     "name:eng_x_preferred":[
         "Neuch\u00e2tel Airport"
     ],
+    "name:eng_x_variant":[
+        "QNC",
+        "LSGN"
+    ],
     "name:fas_x_preferred":[
         "\u0641\u0631\u0648\u062f\u06af\u0627\u0647 \u0646\u0648\u0634\u0627\u062a\u0644"
     ],
@@ -75,7 +79,7 @@
         }
     ],
     "wof:id":102553945,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Aeroport de Neuchatel",
     "wof:parent_id":1125944261,
     "wof:placetype":"campus",

--- a/data/102/553/953/102553953.geojson
+++ b/data/102/553/953/102553953.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Triengen Airport"
     ],
+    "name:eng_x_variant":[
+        "LSPN"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Triengen"
     ],
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102553953,
-    "wof:lastmodified":1566639364,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Triengen",
     "wof:parent_id":1394290769,
     "wof:placetype":"campus",

--- a/data/102/553/977/102553977.geojson
+++ b/data/102/553/977/102553977.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Thun Airport"
     ],
+    "name:eng_x_variant":[
+        "LSZW"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Thun"
     ],
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102553977,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Thun",
     "wof:parent_id":101875985,
     "wof:placetype":"campus",

--- a/data/102/553/979/102553979.geojson
+++ b/data/102/553/979/102553979.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Mollis Airfield"
     ],
+    "name:eng_x_variant":[
+        "LSMF"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Mollis Mil"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553979,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733986,
     "wof:name":"Flugplatz Mollis",
     "wof:parent_id":1125913507,
     "wof:placetype":"campus",

--- a/data/102/553/985/102553985.geojson
+++ b/data/102/553/985/102553985.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "K\u00e4giswil Airport"
     ],
+    "name:eng_x_variant":[
+        "LSPG"
+    ],
     "name:ron_x_preferred":[
         "Aeroportul K\u00e4giswil"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553985,
-    "wof:lastmodified":1566639365,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz K\u00e4giswil",
     "wof:parent_id":101853897,
     "wof:placetype":"campus",

--- a/data/102/553/987/102553987.geojson
+++ b/data/102/553/987/102553987.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Zweisimmen Airport"
     ],
+    "name:eng_x_variant":[
+        "LSTZ"
+    ],
     "name:ron_x_preferred":[
         "Aeroportul Zweisimmen"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553987,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Zweisimmen",
     "wof:parent_id":101854083,
     "wof:placetype":"campus",

--- a/data/102/553/989/102553989.geojson
+++ b/data/102/553/989/102553989.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"7.82333333,46.30444444,7.82333333,46.30444444",
+    "geom:bbox":"7.823333,46.304444,7.823333,46.304444",
     "geom:latitude":46.304444,
     "geom:longitude":7.823333,
     "iso:country":"CH",
@@ -18,6 +18,9 @@
     ],
     "name:eng_x_preferred":[
         "Raron Airport"
+    ],
+    "name:eng_x_variant":[
+        "LSTA"
     ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Raron"
@@ -49,7 +52,7 @@
         "wd:id":"Q1433815"
     },
     "wof:country":"CH",
-    "wof:geomhash":"333ce2d936c8d372e1be8b848c50ea43",
+    "wof:geomhash":"b162c0b02f4c573be3f7fcb779be157f",
     "wof:hierarchy":[
         {
             "campus_id":102553989,
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102553989,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Raron",
     "wof:parent_id":1125850585,
     "wof:placetype":"campus",
@@ -75,10 +78,10 @@
     ]
 },
   "bbox": [
-    7.82333333,
-    46.30444444,
-    7.82333333,
-    46.30444444
+    7.823333,
+    46.304444,
+    7.823333,
+    46.304444
 ],
-  "geometry": {"coordinates":[7.82333333,46.30444444],"type":"Point"}
+  "geometry": {"coordinates":[7.823333,46.304444],"type":"Point"}
 }

--- a/data/102/554/021/102554021.geojson
+++ b/data/102/554/021/102554021.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Wangen-Lachen Airport"
     ],
+    "name:eng_x_variant":[
+        "LSPV"
+    ],
     "name:msa_x_preferred":[
         "Lapangan Terbang Wangen-Lachen"
     ],
@@ -66,7 +69,7 @@
         }
     ],
     "wof:id":102554021,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Wangen-lachen",
     "wof:parent_id":101854009,
     "wof:placetype":"campus",

--- a/data/102/554/025/102554025.geojson
+++ b/data/102/554/025/102554025.geojson
@@ -19,6 +19,9 @@
     "name:eng_x_preferred":[
         "Amlikon Airport"
     ],
+    "name:eng_x_variant":[
+        "LSPA"
+    ],
     "name:ron_x_preferred":[
         "Aeroportul Amlikon"
     ],
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":102554025,
-    "wof:lastmodified":1566639366,
+    "wof:lastmodified":1631733987,
     "wof:name":"Flugplatz Amlikon",
     "wof:parent_id":1394286505,
     "wof:placetype":"campus",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1963

This PR adds existing `iata:code and `icao:code` concordance values as English name variants. If these changes (and two other related PRs) look good, I'll apply them directly to each admin repo.