### PR TITLE
Update names on deisswil

### DIFF
--- a/data/139/439/494/5/1394394945.geojson
+++ b/data/139/439/494/5/1394394945.geojson
@@ -18,74 +18,14 @@
     "lbl:longitude":7.51413,
     "lbl:max_zoom":18.0,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:min_zoom":15.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
-    "name:als_x_preferred":[
+    "name:eng_x_preferred":[
+        "Deisswil"
+    ],
+    "name:eng_x_variant":[
         "Reisiswil"
-    ],
-    "name:ceb_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:chv_x_preferred":[
-        "\u0420\u0430\u0439\u0437\u0438\u0441\u0432\u0438\u043b\u044c"
-    ],
-    "name:deu_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:epo_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:eus_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:fra_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:ita_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:kaz_x_preferred":[
-        "\u0420\u0430\u0439\u0437\u0438\u0441\u0432\u0438\u043b\u044c"
-    ],
-    "name:lmo_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:msa_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:nld_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:nno_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:rus_x_preferred":[
-        "\u0420\u0430\u0439\u0437\u0438\u0441\u0432\u0438\u043b\u044c"
-    ],
-    "name:spa_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:sqi_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:swe_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:vec_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:vie_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:vol_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:war_x_preferred":[
-        "Reisiswil"
-    ],
-    "name:zho_x_preferred":[
-        "\u8cf4\u932b\u65af\u7dad\u723e"
     ],
     "qs_pg:aaroncc":"CH",
     "qs_pg:gn_country":"CH",
@@ -140,8 +80,8 @@
         }
     ],
     "wof:id":1394394945,
-    "wof:lastmodified":1598918625,
-    "wof:name":"Reisiswil",
+    "wof:lastmodified":1703096200,
+    "wof:name":"Deisswil",
     "wof:parent_id":1126015521,
     "wof:placetype":"neighbourhood",
     "wof:repo":"whosonfirst-data-admin-ch",


### PR DESCRIPTION
This PR updates names on Deisswil, removing bogus name translations, but storing the English preferred name as a variant. These name translations come from a Wikipedia crawl, not a concordance, so these names shouldn't re-appear in the future.

**Number of records updated**: 1